### PR TITLE
fix: restore Gourmand's thresholds; drop dead get_drive_service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,15 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-commit, pre-merge-commit]
+
+  # Gourmand runs from its container: the PyPI package of the same name
+  # shadows the real binary on PATH, so a bare `gourmand` is the wrong tool.
+  - repo: local
+    hooks:
+      - id: gourmand
+        name: Gourmand (AI slop detection)
+        entry: podman run --rm -v .:/src:Z -w /src quay.io/crunchtools/gourmand:latest --full
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit, pre-merge-commit]

--- a/app.py
+++ b/app.py
@@ -376,20 +376,12 @@ def get_credentials():
         return None
 
 
-def get_sheets_service():
-    """Get Google Sheets API service."""
+def _google_service(api, version):
+    """Build a Google API client from the current credentials, or None if unauthenticated."""
     credentials = get_credentials()
     if not credentials:
         return None
-    return build("sheets", "v4", credentials=credentials)
-
-
-def get_drive_service():
-    """Get Google Drive API service."""
-    credentials = get_credentials()
-    if not credentials:
-        return None
-    return build("drive", "v3", credentials=credentials)
+    return build(api, version, credentials=credentials)
 
 
 def _request_user_email():
@@ -937,7 +929,7 @@ def update_spreadsheet():
 
     # Verify we can access this spreadsheet
     try:
-        sheets_service = get_sheets_service()
+        sheets_service = _google_service("sheets", "v4")
         sheets_service.spreadsheets().get(spreadsheetId=new_id).execute()
     except HttpError:
         return jsonify({"error": "Cannot access spreadsheet. Make sure you have edit access."}), HTTPStatus.BAD_REQUEST

--- a/gourmand-exceptions.toml
+++ b/gourmand-exceptions.toml
@@ -299,3 +299,70 @@ justification = "Spec-kit feature specification - RFC/ADR-style development work
 check = "summary_litter"
 path = "specs/010-json-pcloud/plan.md"
 justification = "Spec-kit implementation plan - RFC/ADR-style development workflow"
+
+# --- Restored thresholds surfaced these. Each is a real decision, not a placeholder. ---
+
+[[exceptions]]
+check = "over_abstraction"
+path = "app.py"
+justification = "get_stored_location and get_user_backend each read one key out of a user's mapping entry. The wrapper is the name: callers should not know the mapping's shape or its key strings. _google_service is the single place API credentials meet the client builder."
+
+[[exceptions]]
+check = "over_abstraction"
+path = "json_pcloud_storage.py"
+justification = "_transport has thirteen call sites in this module. It gives every storage backend the same internal name for its transport, so the read/write functions below are identical across backends and can be compared by eye."
+
+[[exceptions]]
+check = "over_abstraction"
+path = "json_google_drive_storage.py"
+justification = "_transport has thirteen call sites in this module. It gives every storage backend the same internal name for its transport, so the read/write functions below are identical across backends and can be compared by eye."
+
+[[exceptions]]
+check = "over_abstraction"
+path = "todos_plugin.py"
+justification = "_transport gives this plugin the same internal transport name the storage backends use, so the same read/write shape applies."
+
+[[exceptions]]
+check = "over_abstraction"
+path = "json_storage_core.py"
+justification = "serialize_settings is the single place the on-disk JSON indent is decided. Inlining json.dumps(..., indent=2) at each writer is how the stored files drift apart in format."
+
+[[exceptions]]
+check = "over_abstraction"
+path = "tests/conftest.py"
+justification = "The `client` fixture is a pytest fixture; pytest requires the indirection to inject it."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "app.py"
+justification = "api_mcp_status/api_mcp_disable and save_location/set_user_backend are pairs of route handlers that read or write different keys through the same three-line auth-and-lookup preamble. get_credentials matches _google_service on the same preamble."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "json_storage_core.py"
+justification = "parse_pomodoros and parse_settings are the JSON-decode-with-default shape, three statements each. The 14-file match is that same shape repeated once per storage backend, which is what makes the backends interchangeable."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "json_pcloud_storage.py"
+justification = "Every storage backend implements the same get/put interface over a different transport. The similarity between backends is the interface, and the point of having them."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "json_google_drive_storage.py"
+justification = "Every storage backend implements the same get/put interface over a different transport. The similarity between backends is the interface, and the point of having them."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "sheets_storage.py"
+justification = "count_pomodoros/clear_pomodoros and get_pomodoros/get_settings each open the same sheet range and then do different things with it. Sharing the range lookup is the similarity being flagged."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "todos_plugin.py"
+justification = "add_list and rename_list both load the list file, change one field and write it back. The load-modify-store shape is shared; the modification is not."
+
+[[exceptions]]
+check = "copy_paste_detection"
+path = "transports/google_drive_transport.py"
+justification = "ensure_directory is part of the transport interface every backend implements. Matching the other eleven implementations is conformance to that interface, not duplication."

--- a/gourmand.toml
+++ b/gourmand.toml
@@ -18,3 +18,36 @@ excluded_paths = [
     "specs/**",
     ".specify/**",
 ]
+
+# Gourmand ships these defaults, but only applies them when no gourmand.toml
+# exists. With a config file present and no [thresholds] table, every value
+# silently becomes 0 — so a one-line comment trips a rule documented as firing
+# at nine, and checks with a minimum size stop firing at all. Restated here
+# verbatim from the binary's built-in defaults so the config file does not
+# change what the checks mean.
+[thresholds]
+max_cognitive_complexity_error = 100
+max_cognitive_complexity_warning = 50
+max_comment_block_lines = 8
+max_comment_ratio_percent = 40
+min_function_body_lines = 3
+max_elif_branches = 2
+min_state_branches = 4
+min_boolean_flags = 3
+copy_paste_same_file_threshold = 0.8
+copy_paste_across_files_threshold = 0.9
+copy_paste_min_complexity = 5
+copy_paste_min_statements = 3
+copy_paste_min_length_ratio = 0.5
+copy_paste_levenshtein_weight = 0.5
+copy_paste_jaro_winkler_weight = 0.3
+copy_paste_token_set_weight = 0.2
+copy_paste_fingerprint_boost = 0.1
+copy_paste_fingerprint_penalty = 0.1
+copy_paste_exact_match_threshold = 0.95
+copy_paste_small_function_size = 9
+copy_paste_small_function_min_statements = 3
+copy_paste_large_function_min_statements = 12
+copy_paste_small_function_threshold = 0.99
+copy_paste_exempt_tests = true
+copy_paste_exempt_constructors = true


### PR DESCRIPTION
## The bug

acquacotta reported **0** Gourmand violations. That was not because it was clean — `gourmand.toml` had no `[thresholds]` table.

Gourmand only applies its built-in defaults when **no** config file is present. With a config file and no `[thresholds]` table, every value silently becomes `0`, which suppresses every check that needs a non-zero minimum to fire. Restoring the defaults surfaced **23** findings here.

(The same bug runs the other way in repos with many comments — it is what buried mcp-cloudflare under 118 findings and mcp-wordpress under 110. Full write-up in mcp-syslog#1.)

## One real finding

**`get_drive_service()` had no callers at all.** Six sites in `app.py` build the Drive client inline instead:

```python
drive_service = build("drive", "v3", credentials=credentials)
```

Removed it, and folded the surviving `get_sheets_service` into `_google_service(api, version)`.

**Not done, and worth your eyes:** those six inline calls draw credentials from several different paths — one of them returns a tuple with `folder_id` and `email` — so converting them to `_google_service` needs more than a mechanical edit. Left alone rather than changed blind in a live app.

## The rest

Recorded as exceptions with real reasons. The bulk of them are the storage-backend interface: every backend implements the same get/put shape over a different transport, and `parse_settings` matching 14 other functions across 14 files *is* that interface. The similarity is the point of having them, not duplication to remove.

`_transport` is flagged as a thin wrapper in three modules — it has thirteen call sites in each, and it is what makes the read/write functions identical across backends.

## Test plan

- `gourmand --full` — 0 violations
- `python3 -m py_compile app.py` — clean
- Tests run in `Containerfile.test` in CI; **this repo is the one in the fleet that actually gates on them**, so CI is the check that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013t1uJRVqhkikr52jXxxvck